### PR TITLE
adding the elo calculator

### DIFF
--- a/src/app/lib/elo.library.spec.ts
+++ b/src/app/lib/elo.library.spec.ts
@@ -1,0 +1,35 @@
+/**
+ * elo.library.spec.ts
+ * test file for the elo system
+ */
+
+import { Elo } from './elo.library';
+import { Score } from './util.library';
+import { TestBed } from '@angular/core/testing';
+
+/// Test results are calculated with the FIDE calculator:
+/// https://ratings.fide.com/calculator_rtd.phtml
+
+describe('Elo system', () => {
+	it('should be able to calcuate the right (low-level) elo', () => {
+		const playerA = new Elo(1456, 40);
+		const playerB = new Elo(1790, 40);
+		const result = 1491;
+		playerA.update(playerB.rating, Score.win);
+		expect(playerA.rating).toBe(result);
+	});
+	it('should be able to calcuate the right (mid-level) elo', () => {
+		const playerA = new Elo(1732, 20);
+		const playerB = new Elo(2047, 20);
+		const result = 1739;
+		playerA.update(playerB.rating, Score.draw);
+		expect(playerA.rating).toBe(result);
+	});
+	it('should be able to calcuate the right (high-level) elo', () => {
+		const playerA = new Elo(2761, 10);
+		const playerB = new Elo(2622, 10);
+		const result = 2754;
+		playerA.update(playerB.rating, Score.loss);
+		expect(playerA.rating).toBe(result);
+	});
+});

--- a/src/app/lib/elo.library.ts
+++ b/src/app/lib/elo.library.ts
@@ -6,16 +6,19 @@ export class Elo {
 	private _K: number;
 	private _games: number;
 
-	constructor() {
-		this._rating = 1200;
-		this._K = 40;
-		this._games = 0;
+	constructor(rating?: number, k?: number) {
+		this._rating = rating ?? 1500;
+		this._K = k ?? 40;
+		if (this._K !== 10 &&
+			this._K !== 20 &&
+			this._K !== 40) this._K = 40;
+		this._games = this._K === 40 ? 0 : 30;
 	}
 
 	private expected(opponent: number): number {
-		return 1 / (1 + Math.pow(10, (
-			opponent - this._rating
-		) / 400));
+		let p = opponent - this._rating;
+		if (Math.abs(p) > 400) p = p < 0 ? - 400 : 400;
+		return 1 / (1 + Math.pow(10, p / 400));
 	}
 
 	/// Updates the current Elo according to
@@ -33,7 +36,7 @@ export class Elo {
 	}
 
 	get rating(): number {
-		return Math.floor(this._rating);
+		return Math.round(this._rating);
 	}
 
 	get games(): number {

--- a/src/app/lib/elo.library.ts
+++ b/src/app/lib/elo.library.ts
@@ -1,0 +1,43 @@
+import { Score } from './util.library';
+
+export class Elo {
+
+	private _rating: number;
+	private _K: number;
+	private _games: number;
+
+	constructor() {
+		this._rating = 1200;
+		this._K = 40;
+		this._games = 0;
+	}
+
+	private expected(opponent: number): number {
+		return 1 / (1 + Math.pow(10, (
+			opponent - this._rating
+		) / 400));
+	}
+
+	/// Updates the current Elo according to
+	/// the opponent's Elo and the game score.
+	public update(opponent: number, score: Score) {
+		const E = this.expected(opponent);
+		this._rating += this._K * (score - E);
+		if (this._rating < 100) this._rating = 100;
+		if (this._rating > 3000) this._rating = 3000;
+		this._games++;
+		if (this._K === 10) return;
+		if (this._rating < 2400) {
+			this._K = this._games < 30 ? 40 : 20;
+		} else this._K = 10;
+	}
+
+	get rating(): number {
+		return Math.floor(this._rating);
+	}
+
+	get games(): number {
+		return this._games;
+	}
+
+}

--- a/src/app/lib/util.library.ts
+++ b/src/app/lib/util.library.ts
@@ -36,6 +36,12 @@ export const enum RANK {
     EIGHT
 }
 
+export const enum Score {
+    loss = 0,
+    draw = 0.5,
+    win = 1,
+}
+
 export function fileToString(file: FILE): string {
     return String.fromCharCode(97 + file);
 }


### PR DESCRIPTION
Elo calculator, as FIDE intended. Tested against the real FIDE calculator https://ratings.fide.com/calculator_rtd.phtml.
K factor set to 40 for new players, 20 after 30 games and 10 after 2400.
It stays at 10 even if a player drops below 2400 (as specified by FIDE).
Rating starts at 1500 (as specified by FIDE).
There's a floor of 100 that prevents inflation and a ceiling of 3000 that prevents deflation, however FIDE does not take into account players with a rating less than 1000 so their floor is set to 1000 (but that does not change the formula).
There's a new error correction system in the expected value, since if a **GM** has a very bad day and loses against someone with a very low rating, they don't get punished too much. In fact the same applies to lower rated players who lose to **GM**s and prevents their rating from dropping at all. The threshold that makes the correction system kick in is `|A - B| > 400` where `A` and `B` are the ratings of the two players (as FIDE specifies).
This system is currently in use by different countries, since it's easy to calculate by hand.